### PR TITLE
Include separate shared cycle and footpaths

### DIFF
--- a/src/osm-selectors.ts
+++ b/src/osm-selectors.ts
@@ -71,7 +71,7 @@ export function isGreenRoad(feature: Feature<Geometry, GeoJsonProperties>): bool
   if (p.highway === 'shared_lane') {
     return true;
   }
-  if (p.bicycle === 'designated' && p.highway === 'cycleway') {
+  if (p.bicycle === 'designated' && p.highway === 'path') {
     return true;
   }
   if (p.highway === 'living_street') {


### PR DESCRIPTION
Shared but separate cycle and footpaths with "highway=path" and "bicycle=designated" (see e.g. https://wiki.openstreetmap.org/wiki/Bicycle#Miscellaneous) are not taken into account. Because "p.highway === 'cycleway'" in line 74 is already fulfilled by line 68, "cycleway" could simply be replaced with "path" here.