### PR TITLE
Added side specifiers to bike lanes

### DIFF
--- a/src/osm-selectors.ts
+++ b/src/osm-selectors.ts
@@ -40,7 +40,7 @@ export function isOrangeRoad(feature: Feature<Geometry, GeoJsonProperties>): boo
   if (p.maxspeed <= 40) {
     return true;
   }
-  if (p.cycleway === 'lane') {
+  if (p.cycleway === 'lane' || p['cycleway:left'] === 'lane' || p['cycleway:right'] === 'lane' || p['cycleway:both'] === 'lane') {
     return true;
   }
   return false;


### PR DESCRIPTION
Added new selectors for `cycleway:side=lane` tags. 

These tags are recently being added around Melbourne.